### PR TITLE
linagora/linagora-private#16: Remove proxy from webpack-dev-server

### DIFF
--- a/webpack.commons.js
+++ b/webpack.commons.js
@@ -17,7 +17,6 @@ const pugLoaderOptions = {
 };
 
 const BASE_HREF = process.env.BASE_HREF || '/';
-const OPENPAAS_URL = process.env.OPENPAAS_URL || 'http://localhost:8080';
 
 module.exports = {
   mode: 'development',
@@ -92,40 +91,7 @@ module.exports = {
     compress: true,
     host: '0.0.0.0',
     disableHostCheck: true,
-    port: 9900,
-    proxy: [{
-      context: [
-        '/auth',
-        '/api',
-        '/logout',
-        '/views',
-        '/account/api',
-        '/admin/api',
-        '/profile/app',
-        '/controlcenter/app',
-        '/images',
-        '/socket.io/',
-        '/user-status/app/bubble/',
-        '/user-status/api',
-        '/contact/app',
-        '/contact/api',
-        '/contact/images',
-        '/dav/api',
-        '/unifiedinbox/views',
-        '/unifiedinbox/app',
-        '/unifiedinbox/api',
-        '/calendar/app',
-        '/linagora.esn.resource/api',
-        '/group/api',
-        '/james/api'
-      ],
-      target: OPENPAAS_URL,
-      disableHostCheck: true,
-      historyApiFallback: true,
-      secure: false,
-      changeOrigin: true,
-      withCredentials: true
-    }]
+    port: 9900
   },
   module: {
     rules: [


### PR DESCRIPTION
Using proxy is not relevant anymore as we set the backend URL in env